### PR TITLE
Add Metabase's additional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Metabase secret key can be found in metabase settings page (only accessible by a
 @php($params = ['category' => 'php'])
 <x-metabase dashboard="1" :params="$params"></x-metabase> 
 // BEWARE of the colon in ":params" (not "param") because we are passing array variable directly to the component
+ 
+<!-- passing additional metabase parameters -->
+<x-metabase dashboard="1" :params="$params" :bordered="false" titled theme="night"></x-metabase>
  ```
 
 ## Common Problems

--- a/src/MetabaseComponent.php
+++ b/src/MetabaseComponent.php
@@ -10,6 +10,12 @@ class MetabaseComponent extends Component
 
     public ?int $question;
 
+    public bool $bordered;
+
+    public bool $titled;
+
+    public ?string $theme;
+
     /**
      * @var string[]
      */
@@ -22,11 +28,14 @@ class MetabaseComponent extends Component
      * @param int|null $question
      * @param array<string> $params
      */
-    public function __construct(?int $dashboard = null, ?int $question = null, array $params = [])
+    public function __construct(?int $dashboard = null, ?int $question = null, array $params = [], $bordered = true, $titled = false, $theme = null)
     {
         $this->dashboard = $dashboard;
         $this->question = $question;
         $this->params = $params;
+        $this->bordered = $bordered;
+        $this->titled = $titled;
+        $this->theme = $theme;
     }
 
     /**
@@ -38,7 +47,21 @@ class MetabaseComponent extends Component
     {
         $metabase = app(MetabaseService::class);
         $metabase->setParams($this->params);
+        $metabase->setAdditionalParams($this->getAdditionalParams());
         $iframeUrl = $metabase->generateEmbedUrl((int) $this->dashboard, (int) $this->question);
         return view('metabase::iframe', compact('iframeUrl'));
+    }
+
+
+    private function getAdditionalParams()
+    {
+        $additionalParameters['bordered'] = $this->bordered;
+        $additionalParameters['titled'] = $this->titled;
+
+        if($this->theme) {
+            $additionalParameters['theme'] = $this->theme;
+        }
+
+        return $additionalParameters;
     }
 }

--- a/src/MetabaseComponent.php
+++ b/src/MetabaseComponent.php
@@ -28,7 +28,7 @@ class MetabaseComponent extends Component
      * @param int|null $question
      * @param array<string> $params
      */
-    public function __construct(?int $dashboard = null, ?int $question = null, array $params = [], $bordered = true, $titled = false, $theme = null)
+    public function __construct(?int $dashboard = null, ?int $question = null, array $params = [], $bordered = false, $titled = false, $theme = null)
     {
         $this->dashboard = $dashboard;
         $this->question = $question;

--- a/src/MetabaseService.php
+++ b/src/MetabaseService.php
@@ -15,6 +15,11 @@ class MetabaseService
     private $params;
 
     /**
+     * @var array<string> @params
+     */
+    private $additionalParams;
+
+    /**
      * @param array<string> $params
      *
      * @return void
@@ -26,6 +31,16 @@ class MetabaseService
         }
 
         $this->params = $params;
+    }
+
+    /**
+     * @param array $params
+     *
+     * @return void
+     */
+    public function setAdditionalParams(array $params): void
+    {
+        $this->additionalParams = $params;
     }
 
     private string $type = 'dashboard';
@@ -62,7 +77,7 @@ class MetabaseService
             ->toString();
 
         return sprintf(
-            '%s/embed/%s/%s#bordered=true&titled=false',
+            '%s/embed/%s/%s#' . http_build_query($this->additionalParams),
             config('services.metabase.url'),
             $this->type,
             $token


### PR DESCRIPTION
This PR adds the possibility to use Metabase's [additional parameters](https://www.metabase.com/docs/latest/administration-guide/13-embedding.html#additional-parameters):

- bordered
- titled
- theme

Currently those are hard-coded.

`bordered` currently defaults to `true`. I would prefer to default this to `false` so that you don't have to actually disable it in the blade component:
```
<x-metabase dashboard="1" :params="$params" :bordered="false"></x-metabase>
``` 
Enabling would be easy:
```
<x-metabase dashboard="1" :params="$params" bordered></x-metabase>
```
I have left it like before so that this PR is not breaking.